### PR TITLE
Select only `datetime` and `sensor_value` columns by default

### DIFF
--- a/aerosense_tools/queries.py
+++ b/aerosense_tools/queries.py
@@ -23,6 +23,7 @@ class BigQuery:
         start=None,
         finish=None,
         row_limit=ROW_LIMIT,
+        columns=None,
     ):
         """Get sensor data for the given sensor type on the given node of the given installation over the given time
         period. The time period defaults to the last day.
@@ -33,6 +34,7 @@ class BigQuery:
         :param datetime.datetime|None start: defaults to 1 day before the given finish
         :param datetime.datetime|None finish: defaults to the current datetime
         :param int|None row_limit: if set to `None`, no row limit is applied; if set to an integer, the row limit is set to this; defaults to 10000
+        :param iter(str)|None: the names of the columns to select
         :return (pandas.Dataframe, bool): the sensor data and whether the data has been limited by a row limit
         """
         table_name = f"aerosense-twined.greta.sensor_data_{sensor_type_reference}"
@@ -54,8 +56,10 @@ class BigQuery:
             ]
         )
 
+        columns = columns or ("datetime", "sensor_value")
+
         data_query = f"""
-        SELECT *
+        SELECT {', '.join(columns)}
         FROM `{table_name}`
         {conditions}
         ORDER BY datetime
@@ -85,6 +89,7 @@ class BigQuery:
         sensor_type_reference,
         datetime,
         tolerance=1,
+        columns=None,
     ):
         """Get sensor data for the given sensor type on the given node of the given installation at the given datetime.
         The first datetime within a tolerance of ±0.5 * `tolerance` is used.
@@ -94,6 +99,7 @@ class BigQuery:
         :param str sensor_type_reference: the type of sensor from which to get the data
         :param datetime.datetime|None datetime: the datetime to get the data at
         :param float tolerance: the tolerance on the given datetime in seconds
+        :param iter(str)|None: the names of the columns to select
         :return pandas.Dataframe: the sensor data at the given datetime
         """
         table_name = f"aerosense-twined.greta.sensor_data_{sensor_type_reference}"
@@ -110,8 +116,10 @@ class BigQuery:
             ]
         )
 
+        columns = columns or ("datetime", "sensor_value")
+
         query = f"""
-        SELECT *
+        SELECT {', '.join(columns)}
         FROM `{table_name}`
         WHERE datetime >= @start_datetime
         AND datetime < @finish_datetime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 name = "aerosense-tools"
 version = "0.3.3"
 description = "Functions for working with aerosense data, useful in building dashboards, analysis notebooks and digital twin services"
-authors = ["Tom Clark", "Marcus Lugg", "Yuriy Marykovsky"]
+authors = ["Tom Clark <tom@octue.com>", "Marcus Lugg <marcus@octue.com>", "Yuriy Marykovsky <yuriy.marykovskiy@ost.ch>"]
 license = "BSD-3"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [tool.poetry]
 name = "aerosense-tools"
-version = "0.3.2"
+version = "0.3.3"
 description = "Functions for working with aerosense data, useful in building dashboards, analysis notebooks and digital twin services"
 authors = ["Tom Clark", "Marcus Lugg", "Yuriy Marykovsky"]
 license = "BSD-3"


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#15](https://github.com/aerosense-ai/aerosense-tools/pull/15))

### Fixes
- Select only `datetime` and `sensor_value` columns by default

### Operations
- Add author email addresses to `pyproject.toml`

<!--- END AUTOGENERATED NOTES --->