### PR TITLE
Use UTC time for time-range options

### DIFF
--- a/aerosense_tools/utils.py
+++ b/aerosense_tools/utils.py
@@ -29,12 +29,12 @@ def generate_time_range(time_range, custom_start_date=None, custom_end_date=None
     :return (datetime.datetime, datetime.datetime, bool): the start and finish datetimes
     """
     if time_range == "All time":
-        return datetime.datetime.min, datetime.datetime.now()
+        return datetime.datetime.min, datetime.datetime.utcnow()
 
     if time_range == "Custom":
         return custom_start_date, custom_end_date
 
-    finish = datetime.datetime.now()
+    finish = datetime.datetime.utcnow()
     start = finish - TIME_RANGE_OPTIONS[time_range]
     return start, finish
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [tool.poetry]
 name = "aerosense-tools"
-version = "0.6.1"
+version = "0.6.2"
 description = "Functions for working with aerosense data, useful in building dashboards, analysis notebooks and digital twin services"
 authors = ["Tom Clark", "Marcus Lugg", "Yuriy Marykovsky"]
 license = "BSD-3"


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#23](https://github.com/aerosense-ai/aerosense-tools/pull/23))
Timestamps in greta.sensor_data are in UTC, so when querying for "last hour, last minute etc", utcnow() should be used.

### Bug fixes
- Use UTC time for time-range semantic options

<!--- END AUTOGENERATED NOTES --->